### PR TITLE
DM-9808: astshim does not build on Ubuntu

### DIFF
--- a/ups/starlink_ast.cfg
+++ b/ups/starlink_ast.cfg
@@ -6,9 +6,12 @@ import subprocess
 dependencies = {}
 
 _astLibStr = subprocess.check_output("ast_link", shell=True).decode()
+# sconsUtils requires prerequisites first; ast_link gives them last
+astLibs = _astLibStr.split()
+astLibs.reverse()
 
 config = lsst.sconsUtils.ExternalConfiguration(
     __file__,
     headers = ["ast.h", "ast_err.h"],
-    libs = _astLibStr.split(),
+    libs = astLibs,
 )


### PR DESCRIPTION
This change allows packages that depend on AST to be built with compilers that require libraries to be given in a specific order.