### PR TITLE
DM-11895: Support getting data for current card of FitsChan

### DIFF
--- a/ast_tester/testfitschan.f
+++ b/ast_tester/testfitschan.f
@@ -5,6 +5,7 @@
 
       integer status, fs, fc, i, val
       character cards(10)*80, card*80
+      logical there
 
       status = sai__ok
 
@@ -22,11 +23,12 @@ c      call ast_watchmemory( 225192 )
       cards(2) = 'CRPIX2  =                   45'
       cards(3) = 'CRVAL1  =                   45'
       cards(4) = 'CRVAL2  =                 89.9'
-      cards(5) = 'CDELT1  =                -0.01'
-      cards(6) = 'CDELT2  =                 0.01'
-      cards(7) = 'CTYPE1  = ''RA---TAN'''
-      cards(8) = 'CTYPE2  = ''DEC--TAN'''
-      do i = 1, 8
+      cards(5) = 'MYNAME  =                     '
+      cards(6) = 'CDELT1  =                -0.01'
+      cards(7) = 'CDELT2  =                 0.01'
+      cards(8) = 'CTYPE1  = ''RA---TAN'''
+      cards(9) = 'CTYPE2  = ''DEC--TAN'''
+      do i = 1, 9
          call ast_putfits( fc, cards(i), .false., status )
       end do
 
@@ -37,6 +39,26 @@ c      call ast_watchmemory( 225192 )
          call stopit( 778, ' ', status )
       endif
 
+      call ast_seti( fc, 'Card', 5, status )
+      if( ast_testfits( fc, '.', there, status ) ) then
+         call stopit( 779, ' ', status )
+      else if( .not. there ) then
+         call stopit( 780, ' ', status )
+      endif
+
+      if( .not. ast_testfits( fc, 'CDELT1', there, status ) ) then
+         call stopit( 781, ' ', status )
+      else if( .not. there ) then
+         call stopit( 782, ' ', status )
+      endif
+
+      if( ast_testfits( fc, 'ABCDEF', there, status ) ) then
+         call stopit( 783, ' ', status )
+      else if( there ) then
+         call stopit( 784, ' ', status )
+      endif
+
+
 *  Annul the fitschan. Only 1 ref so this should delete it.
       call ast_annul( fc, status )
 
@@ -45,12 +67,12 @@ c      call ast_watchmemory( 225192 )
      :                   status )
 
 *  Check it looks like the original header.
-      if( ast_geti( fc, 'NCard', status ) .ne. 8 ) then
+      if( ast_geti( fc, 'NCard', status ) .ne. 9 ) then
          write(*,*) ast_geti( fc, 'NCard', status )
          call stopit( 1000, ' ', status )
       endif
 
-      if( ast_geti( fc, 'Nkey', status ) .ne. 8 ) then
+      if( ast_geti( fc, 'Nkey', status ) .ne. 9 ) then
          write(*,*) ast_geti( fc, 'Nkey', status )
          call stopit( 999, ' ', status )
       endif

--- a/ast_tester/testfitschan.f
+++ b/ast_tester/testfitschan.f
@@ -58,6 +58,15 @@ c      call ast_watchmemory( 225192 )
          call stopit( 784, ' ', status )
       endif
 
+      call ast_seti( fc, 'Card', 10, status )
+      if( ast_testfits( fc, '.', there, status ) ) then
+         call stopit( 785, ' ', status )
+      else if( there ) then
+         call stopit( 786, ' ', status )
+      endif
+
+      card = ast_getc( fc, 'CardName', status )
+      if( card .ne. ' ' ) call stopit( 787, ' ', status )
 
 *  Annul the fitschan. Only 1 ref so this should delete it.
       call ast_annul( fc, status )

--- a/ffitschan.c
+++ b/ffitschan.c
@@ -820,6 +820,7 @@ F77_LOGICAL_FUNCTION(ast_testfits)( INTEGER(THIS),
    astAt( "AST_TESTFITS", NULL, 0 );
    astWatchSTATUS(
       name = astString( NAME, NAME_length );
+      if( name && !strcmp( name, "." ) ) name = astFree( name ); \
       RESULT = astTestFits( astI2P( *THIS ), name, &there ) ?
                F77_TRUE : F77_FALSE;
       (void) astFree( (void *) name );

--- a/fitschan.c
+++ b/fitschan.c
@@ -32281,12 +32281,15 @@ f     -  .FALSE.
 /* Get the card type. */
       type = CardType( this, status );
 
-/* If the cards data type is no undefined, return 1. */
-      if( CardType( this, status ) != AST__UNDEF ) ret = 1;
+/* Check the card exists. */
+      if( type != AST__NOTYPE ) {
 
-/* Indicate the card has been found. No card was found if the type is
-   AST__NOTYPE (as can happen if the FitsChan is empty and lname is NULL). */
-      if( there && type != AST__NOTYPE ) *there = 1;
+/* If the cards data type is not undefined, return 1. */
+         if( CardType( this, status ) != AST__UNDEF ) ret = 1;
+
+/* Indicate the card has been found. */
+         if( there ) *there = 1;
+      }
    }
 
 /* Re-instate the original current card index. */

--- a/object.c
+++ b/object.c
@@ -229,8 +229,12 @@ f     - AST_VERSION: Return the verson of the AST library being used.
 *        This is needed because supplying the while settings string in
 *        place of "%s" is considered a security issue by many compilers.
 *     4-JUL-2017 (DSB):
-*        Within astLockId, perform the correct check that the supplied 
+*        Within astLockId, perform the correct check that the supplied
 *        object handle is not locked by another thread.
+*     13-SEP-2017 (DSB):
+*        Ensure the Get function only returns a NULL pointer under error 
+*        conditions. A NULL in cases where no error has occurred can cause
+*        later code to segfault.
 *class--
 */
 
@@ -2032,6 +2036,10 @@ static const char *Get( AstObject *this, const char *attrib, int *status ) {
 
 /* If required, strip out graphical escape sequences. */
          if( !astEscapes( -1 ) ) result = astStripEscapes( result );
+
+/* This function only returns a NULL pointer if an error occurs. Use a
+   null string instead otherwise. */
+         if( astOK && !result ) result = "";
       }
    }
 
@@ -7352,7 +7360,7 @@ c--
 /* Ensure the Handles arrays have been initialised. */
    if ( !active_handles ) InitContext( status );
 
-/* Get the Handle index for the supplied object identifier. Report an 
+/* Get the Handle index for the supplied object identifier. Report an
    error if the handle is associated with a different thread (no error
    if the handle has no associated thread or is associated with the
    current thread). */


### PR DESCRIPTION
This pull request is intended to merge recent changes on master into our lsst-dev branch. The main purpose of those changes is to support calling `astTestFits(NULL)` to get information about the current card in an `astFitsChan`.